### PR TITLE
ffbs-mesh-vpn-parker: delete firewall rules for the prefix6 site config

### DIFF
--- a/ffbs-mesh-vpn-parker/files/lib/gluon/upgrade/401-respondd-firewall-parker
+++ b/ffbs-mesh-vpn-parker/files/lib/gluon/upgrade/401-respondd-firewall-parker
@@ -1,0 +1,13 @@
+#!/usr/bin/lua
+
+local uci = require('simple-uci').cursor()
+
+-- The mesh_respondd_siteprefix and mesh_respondd_extraprefix[0-9]+ rules
+-- do not make sense in the context of parker as there are no prefix4
+-- and prefix6 attributes anymore.
+uci:delete('firewall', 'rule', 'mesh_respondd_siteprefix')
+uci:delete_all('firewall', 'rule', function(rule)
+	return rule['.name']:find('^mesh_respondd_extraprefix')
+end)
+
+uci:save('firewall')


### PR DESCRIPTION
As suggested [here](https://github.com/freifunk-gluon/community-packages/pull/142#issuecomment-2489694858) by @maurerle 

Can remove diff at https://github.com/ffbs/gluon-parker/commit/2e53380d2ff00f26d840e3f46bf12c9c76d9f15f#diff-70c0178fef0afe6aa581fdd24bcd19c5ad4f04874648698469f5f5896dc1b500L36