### PR TITLE
ffbs-mesh-vpn-parker: move parker pubkey to uci

### DIFF
--- a/ffbs-mesh-vpn-parker/files/usr/sbin/nodeconfig.sh
+++ b/ffbs-mesh-vpn-parker/files/usr/sbin/nodeconfig.sh
@@ -3,7 +3,7 @@
 # THIS SCRIPT MUST HAVE GID 800 (gluon-mesh-vpn)
 # USE `gluon-wan nodeconfig.sh`
 # !!!!!!
-SIGN_PUB_KEY=/etc/parker/node-config-pub.key
+SIGN_PUB_KEY=/tmp/ff-Ohb0ba0u/nodeconfig-pub.key
 DEFAULT_SLEEP=20
 export LIBPACKETMARK_MARK=1
 
@@ -29,6 +29,11 @@ else
 fi
 
 pubkey=$(sed 's/+/%2B/g' /etc/parker/wg-pubkey)
+
+if ! { echo "untrusted comment: signify public key" && uci -q get parker.nodeconfig.config_pubkey; } > "${SIGN_PUB_KEY}"; then
+    $LOGGER unable to read pubkey from uci or write it to "${SIGN_PUB_KEY}"
+    exit 1
+fi
 
 while true; do
     vpn_enabled=$(uci get gluon.mesh_vpn.enabled)

--- a/ffbs-mesh-vpn-parker/luasrc/lib/gluon/upgrade/906-parker-nodeconfig
+++ b/ffbs-mesh-vpn-parker/luasrc/lib/gluon/upgrade/906-parker-nodeconfig
@@ -4,14 +4,11 @@ local site = require 'gluon.site'
 local uci = require('simple-uci').cursor()
 
 local site_config_server = site.parker.config_server()
+local site_config_pubkey = site.parker.config_pubkey()
 uci:section('parker', 'nodeconfig', 'nodeconfig',
-    { config_server = site_config_server }
+	{
+		config_server = site_config_server,
+		config_pubkey = site_config_pubkey,
+	}
 )
 uci:save('parker')
-
-local site_config_pubkey = site.parker.config_pubkey()
-os.execute("mkdir -p /etc/parker/")
-local pub_fh = io.open("/etc/parker/node-config-pub.key", "w")
-pub_fh:write("untrusted comment: signify public key\n")
-pub_fh:write(site_config_pubkey)
-pub_fh:close()


### PR DESCRIPTION
Also moving the pubkey file to /tmp/ as it will be written every time that nodeconfig is run.