### PR TITLE
ffbs-mesh-vpn-parker: fix default parker config

### DIFF
--- a/ffbs-mesh-vpn-parker/files/etc/config/parker
+++ b/ffbs-mesh-vpn-parker/files/etc/config/parker
@@ -1,4 +1,3 @@
 
-config nodeconfig 'example'
+config nodeconfig 'nodeconfig'
 	option config_server 'config.community.example'
-


### PR DESCRIPTION
This avoids having multiple entries in the parker uci config 